### PR TITLE
Use fixed-rate scheduled task in messenger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target/
+target/
 /.idea/
 *.log
 /docs/*.~vsd

--- a/core/src/main/java/com/ibasco/agql/core/messenger/GameServerMessenger.java
+++ b/core/src/main/java/com/ibasco/agql/core/messenger/GameServerMessenger.java
@@ -31,7 +31,7 @@ import com.ibasco.agql.core.enums.ProcessingMode;
 import com.ibasco.agql.core.session.AbstractSessionIdFactory;
 import com.ibasco.agql.core.session.SessionManager;
 
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Messenger using the UDP Transport protocol
@@ -47,7 +47,7 @@ abstract public class GameServerMessenger<A extends AbstractGameServerRequest, B
         super(keyFactory, processingMode);
     }
 
-    public GameServerMessenger(SessionManager sessionManager, ProcessingMode processingMode, int initQueueCapacity, ExecutorService executorService) {
+    public GameServerMessenger(SessionManager sessionManager, ProcessingMode processingMode, int initQueueCapacity, ScheduledExecutorService executorService) {
         super(sessionManager, processingMode, initQueueCapacity, executorService);
     }
 }


### PR DESCRIPTION
Replaces the while loop inside ``AbstractMessenger#start()`` with a fixed-rate scheduled task to help with CPU time.

Includes a .gitignore modification to not check any ``target`` folders into source control.