### PR TITLE
feat(gh-165): support for GraalVM

### DIFF
--- a/core/src/main/resources/META-INF/native-image/com.ibasco.agql/async-gamequery-lib/reflect-config.json
+++ b/core/src/main/resources/META-INF/native-image/com.ibasco.agql/async-gamequery-lib/reflect-config.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "com.ibasco.agql.core.util.ConnectOptions",
+    "allPublicFields": true,
+    "allPublicConstructors": true
+  },
+  {
+    "name": "com.ibasco.agql.core.util.FailsafeOptions",
+    "allPublicFields": true,
+    "allPublicConstructors": true
+  },
+  {
+    "name": "com.ibasco.agql.core.util.GeneralOptions",
+    "allPublicFields": true,
+    "allPublicConstructors": true
+  },
+  {
+    "name": "com.ibasco.agql.core.util.HttpOptions",
+    "allPublicFields": true,
+    "allPublicConstructors": true
+  },
+  {
+    "name": "com.ibasco.agql.protocols.valve.source.query.SourceQueryOptions",
+    "allPublicFields": true,
+    "allPublicConstructors": true
+  }
+]


### PR DESCRIPTION
Fixes https://github.com/ribasco/async-gamequery-lib/issues/165.

Adds native-image reflection hints required to create `*Options` class instances.

Netty is already compatible with native-image via https://github.com/oracle/graalvm-reachability-metadata. Details can be found here: https://www.graalvm.org/native-image/libraries-and-frameworks/

Tests could also be executed against the native executable using:
```
<plugin>
    <groupId>org.graalvm.buildtools</groupId>
    <artifactId>native-maven-plugin</artifactId>
</plugin>
```

However, i only found a few tests in the project, so i'd need some input here.